### PR TITLE
haris/setup.py-fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 from oxylabs.version import SDK_VERSION
 
@@ -6,7 +6,7 @@ long_description = """
 The official Python library for the Oxylabs Scraper APIs.
 
 Collect public data at scale with industry-leading web scraping solutions and the world's largest ethical proxy network.
-Documentation can be found at [https://github.com/mslmio/oxylabs-sdk-python](https://github.com/mslmio/oxylabs-sdk-python).
+Documentation can be found at https://github.com/mslmio/oxylabs-sdk-python.
 """
 
 setup(
@@ -18,6 +18,6 @@ setup(
     author="Oxylabs",
     author_email="support@oxylabs.io",
     license="MIT",
-    packages=["oxylabs"],
+    packages=find_packages(),
     install_requires=["aiohttp", "requests"],
 )


### PR DESCRIPTION
@UmanShahzad The url seems to be broken, doesn't redirect to actual documentation, secondly the published package doesn't pick up any sub-folders included within the parent oxylabs folder since we didn't specify that in our setup.py resulting in the package not working.

This should work now since I have made the build locally first and its picking up the sub-folders just need to publish it.

I'll test it once this is merged and published.